### PR TITLE
Updated ILoopFunction interface

### DIFF
--- a/collections.d.ts
+++ b/collections.d.ts
@@ -21,7 +21,7 @@ declare module collections {
     * Function signature for Iterations. Return false to break from loop
     */
     interface ILoopFunction<T> {
-        (a: T): boolean;
+        (a: T): boolean | void;
     }
     /**
      * Default function to compare element order.
@@ -157,7 +157,7 @@ declare module collections {
          * invoked with one argument: the element value, to break the iteration you can
          * optionally return false.
          */
-        function forEach<T>(array: T[], callback: (item: T) => boolean): void;
+        function forEach<T>(array: T[], callback: ILoopFunction<T>): void;
     }
     interface ILinkedListNode<T> {
         element: T;
@@ -304,7 +304,7 @@ declare module collections {
          * invoked with one argument: the element value, to break the iteration you can
          * optionally return false.
          */
-        forEach(callback: (item: T) => boolean): void;
+        forEach(callback: ILoopFunction<T>): void;
         /**
          * Reverses the order of the elements in this linked list (makes the last
          * element first, and the first element last).
@@ -782,7 +782,7 @@ declare module collections {
          * invoked with one argument: the element value, to break the iteration you can
          * optionally return false.
          */
-        forEach(callback: (item: T) => boolean): void;
+        forEach(callback: ILoopFunction<T>): void;
     }
     class Stack<T> {
         /**

--- a/collections.ts
+++ b/collections.ts
@@ -35,7 +35,7 @@ module collections {
     * Function signature for Iterations. Return false to break from loop
     */
     export interface ILoopFunction<T>{
-        (a: T): boolean;
+        (a: T): boolean | void;
     }
 
     /**
@@ -321,7 +321,7 @@ module collections {
          * invoked with one argument: the element value, to break the iteration you can 
          * optionally return false.
          */
-        export function forEach<T>(array: T[], callback: (item: T) => boolean): void {
+        export function forEach<T>(array: T[], callback: ILoopFunction<T>): void {
             var lenght = array.length;
             for (var i = 0; i < lenght; i++) {
                 if (callback(array[i]) === false) {
@@ -639,7 +639,7 @@ module collections {
          * invoked with one argument: the element value, to break the iteration you can 
          * optionally return false.
          */
-        forEach(callback: (item: T) => boolean): void {
+        forEach(callback: ILoopFunction<T>): void {
             var currentNode = this.firstNode;
             while (currentNode !== null) {
                 if (callback(currentNode.element) === false) {
@@ -1592,7 +1592,7 @@ module collections {
          * invoked with one argument: the element value, to break the iteration you can 
          * optionally return false.
          */
-        forEach(callback: (item: T) => boolean) {
+        forEach(callback: ILoopFunction<T>) {
             collections.arrays.forEach(this.data, callback);
         }
     }


### PR DESCRIPTION
The return type can now be boolean or void.
This avoid adding a return true if the funcyion does not need to stop early.
Some other foreach functions now use this interface.
