### PR TITLE
[fix_makestring_example] bad call to makeString in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class Car {
     }
     toString() {
         // Short hand. Adds each own property 
-        return Collections.makeString(this);
+        return Collections.util.makeString(this);
     }
 }
 ```
@@ -127,7 +127,7 @@ class Car {
     }
     toString() {
         // Short hand. Adds each own property 
-        return Collections.toString(this);
+        return Collections.util.makeString(this);
     }
 }
 var dict = new Collections.Dictionary<Person, Car>();


### PR DESCRIPTION
Hi, just a small error, but thanks a lot for this project.

It is impossible to compile this example in `README.md` :  

file `car.ts`   

``` typescript
import * as Collections from 'typescript-collections';

class Car {
    constructor(public company: string, public type: string, public year: number) {
    }
    toString() {
        // Short hand. Adds each own property 
        return Collections.makeString(this);
    }
}
```

with `tsc car.ts` the output is : 

```
car.ts(8,28): error TS2339: Property 'makeString' does not exist  ...
```

Here the fix:  

```
import * as Collections from 'typescript-collections';

class Car {
    constructor(public company: string, public type: string, public year: number) {
    }
    toString() {
        // Short hand. Adds each own property 
        return Collections.util.makeString(this);
    }
}

console.log(new Car("BMW", "A", 2016).toString());
```

After compiling and executing respectively with `tsc car.ts` then `node car.js`, you have well:  

```
{company:BMW,type:A,year:2016}
```
