### PR TITLE
Add entries() function to Dictionary

### DIFF
--- a/src/lib/Dictionary.ts
+++ b/src/lib/Dictionary.ts
@@ -157,8 +157,8 @@ export default class Dictionary<K, V>{
      * Returns an array of all key, value pairs in this dictionary.
      * @return {Array} an array containing all of the key, value pairs in this dictionary.
      */
-    entries(): [K,V][] {
-        const array: V[] = [];
+    entries(): [K, V][] {
+        const array: [K, V][] = [];
         for (const name in this.table) {
             if (util.has(this.table, name)) {
                 const pair: IDictionaryPair<K, V> = this.table[name];

--- a/src/lib/Dictionary.ts
+++ b/src/lib/Dictionary.ts
@@ -154,6 +154,21 @@ export default class Dictionary<K, V>{
     }
 
     /**
+     * Returns an array of all key, value pairs in this dictionary.
+     * @return {Array} an array containing all of the key, value pairs in this dictionary.
+     */
+    entries(): [K,V][] {
+        const array: V[] = [];
+        for (const name in this.table) {
+            if (util.has(this.table, name)) {
+                const pair: IDictionaryPair<K, V> = this.table[name];
+                array.push([pair.key, pair.value]);
+            }
+        }
+        return array;
+    }
+
+    /**
     * Executes the provided function once for each key-value pair
     * present in this dictionary.
     * @param {function(Object,Object):*} callback function to execute, it is


### PR DESCRIPTION
Take this, or leave it. It makes the code I'm writing much cleaner to have.

This allows one to call `dictionary.entries()` to receive a `[K,V][]` return. The language used for documentation mimics the Array entries language packaged by @types/node.