### PR TITLE
fixed next being undefined instead of null

### DIFF
--- a/src/lib/LinkedDictionary.ts
+++ b/src/lib/LinkedDictionary.ts
@@ -37,7 +37,7 @@ class HeadOrTailLinkedDictionaryPair<K, V> implements IDictionaryPair<null, null
 
 function isHeadOrTailLinkedDictionaryPair<K, V>(p: HeadOrTailLinkedDictionaryPair<K, V> | LinkedDictionaryPair<K, V>)
         : p is HeadOrTailLinkedDictionaryPair<K, V> {
-    return p.next === null;
+    return !p.next;
 }
 
 export default class LinkedDictionary<K, V> extends Dictionary<K, V> {


### PR DESCRIPTION
Problem here is that if we call foreach() of values() function, isHeadOrTailLinkedDictionaryPair never returns true and we get a npe, because tail.next === null is always false. It is actually undefined. So a more general check fixes it.