### PR TITLE
Change private modifiers to protected

### DIFF
--- a/src/lib/BSTreeKV.ts
+++ b/src/lib/BSTreeKV.ts
@@ -20,9 +20,9 @@ interface BSTreeNode<T> {
  */
 export default class BSTreeKV<K, V extends K> {
 
-    private root: BSTreeNode<V> | null;
-    private compare: util.ICompareFunction<K>;
-    private nElements: number;
+    protected root: BSTreeNode<V> | null;
+    protected compare: util.ICompareFunction<K>;
+    protected nElements: number;
     /**
      * Creates an empty binary search tree.
      * @class <p>A binary search tree is a binary tree in which each
@@ -246,9 +246,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private searchNode(node: BSTreeNode<V> | null, element: K): BSTreeNode<V> | null {
+    protected searchNode(node: BSTreeNode<V> | null, element: K): BSTreeNode<V> | null {
         let cmp: number = 1;
         while (node !== null && cmp !== 0) {
             cmp = this.compare(element, node.element);
@@ -262,9 +262,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private transplant(n1: BSTreeNode<V>, n2: BSTreeNode<V> | null): void {
+    protected transplant(n1: BSTreeNode<V>, n2: BSTreeNode<V> | null): void {
         if (n1.parent === null) {
             this.root = n2;
         } else if (n1 === n1.parent.leftCh) {
@@ -278,9 +278,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private removeNode(node: BSTreeNode<V>): void {
+    protected removeNode(node: BSTreeNode<V>): void {
         if (node.leftCh === null) {
             this.transplant(node, node.rightCh);
         } else if (node.rightCh === null) {
@@ -299,9 +299,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private inorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }): void {
+    protected inorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }): void {
         if (node === null || signal.stop) {
             return;
         }
@@ -317,9 +317,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private levelTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>) {
+    protected levelTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>) {
         const queue = new Queue<BSTreeNode<V>>();
         if (node !== null) {
             queue.enqueue(node);
@@ -340,9 +340,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private preorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }) {
+    protected preorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }) {
         if (node === null || signal.stop) {
             return;
         }
@@ -357,9 +357,9 @@ export default class BSTreeKV<K, V extends K> {
         this.preorderTraversalAux(node.rightCh, callback, signal);
     }
     /**
-     * @private
+     * @protected
      */
-    private postorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }) {
+    protected postorderTraversalAux(node: BSTreeNode<V> | null, callback: util.ILoopFunction<V>, signal: { stop: boolean; }) {
         if (node === null || signal.stop) {
             return;
         }
@@ -375,11 +375,11 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private minimumAux(node: BSTreeNode<V>): BSTreeNode<V>;
-    private minimumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null;
-    private minimumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null {
+    protected minimumAux(node: BSTreeNode<V>): BSTreeNode<V>;
+    protected minimumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null;
+    protected minimumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null {
         while (node != null && node.leftCh !== null) {
             node = node.leftCh;
         }
@@ -387,11 +387,11 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private maximumAux(node: BSTreeNode<V>): BSTreeNode<V>;
-    private maximumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null;
-    private maximumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null {
+    protected maximumAux(node: BSTreeNode<V>): BSTreeNode<V>;
+    protected maximumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null;
+    protected maximumAux(node: BSTreeNode<V> | null): BSTreeNode<V> | null {
         while (node != null && node.rightCh !== null) {
             node = node.rightCh;
         }
@@ -399,9 +399,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private heightAux(node: BSTreeNode<V> | null): number {
+    protected heightAux(node: BSTreeNode<V> | null): number {
         if (node === null) {
             return -1;
         }
@@ -409,9 +409,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /*
-    * @private
+    * @protected
     */
-    private insertNode(node: BSTreeNode<V>): BSTreeNode<V> | null {
+    protected insertNode(node: BSTreeNode<V>): BSTreeNode<V> | null {
 
         let parent: any = null;
         let position = this.root;
@@ -440,9 +440,9 @@ export default class BSTreeKV<K, V extends K> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private createNode(element: V): BSTreeNode<V> {
+    protected createNode(element: V): BSTreeNode<V> {
         return {
             element: element,
             leftCh: null,

--- a/src/lib/Bag.ts
+++ b/src/lib/Bag.ts
@@ -4,9 +4,9 @@ import Set from './Set';
 
 export default class Bag<T> {
 
-    private toStrF: (item: T) => string;
-    private dictionary: Dictionary<T, any>;
-    private nElements: number;
+    protected toStrF: (item: T) => string;
+    protected dictionary: Dictionary<T, any>;
+    protected nElements: number;
 
     /**
      * Creates an empty bag.

--- a/src/lib/Dictionary.ts
+++ b/src/lib/Dictionary.ts
@@ -12,7 +12,7 @@ export default class Dictionary<K, V> {
     /**
      * Object holding the key-value pairs.
      * @type {Object}
-     * @private
+     * @protected
      */
     protected table: { [key: string]: IDictionaryPair<K, V> };
     //: [key: K] will not work since indices can only by strings in javascript and typescript enforces this.
@@ -20,7 +20,7 @@ export default class Dictionary<K, V> {
     /**
      * Number of elements in the list.
      * @type {number}
-     * @private
+     * @protected
      */
     protected nElements: number;
 

--- a/src/lib/Heap.ts
+++ b/src/lib/Heap.ts
@@ -5,15 +5,15 @@ export default class Heap<T> {
     /**
      * Array used to store the elements of the heap.
      * @type {Array.<Object>}
-     * @private
+     * @protected
      */
-    private data: T[] = [];
+    protected data: T[] = [];
     /**
      * Function used to compare elements.
      * @type {function(Object,Object):number}
-     * @private
+     * @protected
      */
-    private compare: collections.ICompareFunction<T>;
+    protected compare: collections.ICompareFunction<T>;
     /**
      * Creates an empty Heap.
      * @class
@@ -66,9 +66,9 @@ export default class Heap<T> {
      * @param {number} nodeIndex The index of the node to get the left child
      * for.
      * @return {number} The index of the left child.
-     * @private
+     * @protected
      */
-    private leftChildIndex(nodeIndex: number): number {
+    protected leftChildIndex(nodeIndex: number): number {
         return (2 * nodeIndex) + 1;
     }
     /**
@@ -76,18 +76,18 @@ export default class Heap<T> {
      * @param {number} nodeIndex The index of the node to get the right child
      * for.
      * @return {number} The index of the right child.
-     * @private
+     * @protected
      */
-    private rightChildIndex(nodeIndex: number): number {
+    protected rightChildIndex(nodeIndex: number): number {
         return (2 * nodeIndex) + 2;
     }
     /**
      * Returns the index of the parent of the node at the given index.
      * @param {number} nodeIndex The index of the node to get the parent for.
      * @return {number} The index of the parent.
-     * @private
+     * @protected
      */
-    private parentIndex(nodeIndex: number): number {
+    protected parentIndex(nodeIndex: number): number {
         return Math.floor((nodeIndex - 1) / 2);
     }
     /**
@@ -96,9 +96,9 @@ export default class Heap<T> {
      * @param {number} rightChild right child index.
      * @return {number} the index with the minimum value or -1 if it doesn't
      * exists.
-     * @private
+     * @protected
      */
-    private minIndex(leftChild: number, rightChild: number): number {
+    protected minIndex(leftChild: number, rightChild: number): number {
 
         if (rightChild >= this.data.length) {
             if (leftChild >= this.data.length) {
@@ -117,9 +117,9 @@ export default class Heap<T> {
     /**
      * Moves the node at the given index up to its proper place in the heap.
      * @param {number} index The index of the node to move up.
-     * @private
+     * @protected
      */
-    private siftUp(index: number): void {
+    protected siftUp(index: number): void {
 
         let parent = this.parentIndex(index);
         while (index > 0 && this.compare(this.data[parent], this.data[index]) > 0) {
@@ -131,9 +131,9 @@ export default class Heap<T> {
     /**
      * Moves the node at the given index down to its proper place in the heap.
      * @param {number} nodeIndex The index of the node to move down.
-     * @private
+     * @protected
      */
-    private siftDown(nodeIndex: number): void {
+    protected siftDown(nodeIndex: number): void {
 
         //smaller child index
         let min = this.minIndex(this.leftChildIndex(nodeIndex),

--- a/src/lib/LinkedDictionary.ts
+++ b/src/lib/LinkedDictionary.ts
@@ -41,8 +41,8 @@ function isHeadOrTailLinkedDictionaryPair<K, V>(p: HeadOrTailLinkedDictionaryPai
 }
 
 export default class LinkedDictionary<K, V> extends Dictionary<K, V> {
-    private head: HeadOrTailLinkedDictionaryPair<K, V>; // Head Identifier of the list.  holds no Key or Value
-    private tail: HeadOrTailLinkedDictionaryPair<K, V>; // Tail Identifier of the list.  holds no Key or Value
+    protected head: HeadOrTailLinkedDictionaryPair<K, V>; // Head Identifier of the list.  holds no Key or Value
+    protected tail: HeadOrTailLinkedDictionaryPair<K, V>; // Tail Identifier of the list.  holds no Key or Value
 
     constructor(toStrFunction?: (key: K) => string) {
         super(toStrFunction);
@@ -57,7 +57,7 @@ export default class LinkedDictionary<K, V> extends Dictionary<K, V> {
      * neighbors, and moving 'this.tail' (the End of List indicator) that
      * to the end.
      */
-    private appendToTail(entry: LinkedDictionaryPair<K, V>) {
+    protected appendToTail(entry: LinkedDictionaryPair<K, V>) {
         const lastNode = this.tail.prev;
         lastNode.next = entry;
         entry.prev = lastNode;
@@ -68,7 +68,7 @@ export default class LinkedDictionary<K, V> extends Dictionary<K, V> {
     /**
      * Retrieves a linked dictionary from the table internally
      */
-    private getLinkedDictionaryPair(key: K): LinkedDictionaryPair<K, V> | undefined {
+    protected getLinkedDictionaryPair(key: K): LinkedDictionaryPair<K, V> | undefined {
         if (util.isUndefined(key)) {
             return undefined;
         }
@@ -126,7 +126,7 @@ export default class LinkedDictionary<K, V> extends Dictionary<K, V> {
      * It places the new value indexed by key into the table, but maintains
      * its place in the linked ordering.
      */
-    private replace(oldPair: LinkedDictionaryPair<K, V>, newPair: LinkedDictionaryPair<K, V>) {
+    protected replace(oldPair: LinkedDictionaryPair<K, V>, newPair: LinkedDictionaryPair<K, V>) {
         const k = '$' + this.toStr(newPair.key);
 
         // set the new Pair's links to existingPair's links

--- a/src/lib/LinkedList.ts
+++ b/src/lib/LinkedList.ts
@@ -12,22 +12,22 @@ export default class LinkedList<T> {
     /**
      * First node in the list
      * @type {Object}
-     * @private
+     * @protected
      */
     public firstNode: ILinkedListNode<T> | null = null;
     /**
      * Last node in the list
      * @type {Object}
-     * @private
+     * @protected
      */
-    private lastNode: ILinkedListNode<T> | null = null;
+    protected lastNode: ILinkedListNode<T> | null = null;
 
     /**
      * Number of elements in the list
      * @type {number}
-     * @private
+     * @protected
      */
-    private nElements: number = 0;
+    protected nElements: number = 0;
 
     /**
      * Creates an empty Linked List.
@@ -258,9 +258,9 @@ export default class LinkedList<T> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private equalsAux(n1: ILinkedListNode<T> | null, n2: ILinkedListNode<T> | null, eqF: util.IEqualsFunction<T>): boolean {
+    protected equalsAux(n1: ILinkedListNode<T> | null, n2: ILinkedListNode<T> | null, eqF: util.IEqualsFunction<T>): boolean {
         while (n1 !== null && n2 !== null) {
             if (!eqF(n1.element, n2.element)) {
                 return false;
@@ -376,9 +376,9 @@ export default class LinkedList<T> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private nodeAtIndex(index: number): ILinkedListNode<T> | null {
+    protected nodeAtIndex(index: number): ILinkedListNode<T> | null {
 
         if (index < 0 || index >= this.nElements) {
             return null;
@@ -394,9 +394,9 @@ export default class LinkedList<T> {
     }
 
     /**
-     * @private
+     * @protected
      */
-    private createNode(item: T): ILinkedListNode<T> {
+    protected createNode(item: T): ILinkedListNode<T> {
         return {
             element: item,
             next: null

--- a/src/lib/MultiDictionary.ts
+++ b/src/lib/MultiDictionary.ts
@@ -8,9 +8,9 @@ export default class MultiDictionary<K, V> {
     // class MultiDictionary<K,V> extends Dictionary<K,Array<V>> {
     // Since we want to reuse the function name setValue and types in signature become incompatible
     // Therefore we are using composition instead of inheritance
-    private dict: Dictionary<K, Array<V>>;
-    private equalsF: util.IEqualsFunction<V>;
-    private allowDuplicate: boolean;
+    protected dict: Dictionary<K, Array<V>>;
+    protected equalsF: util.IEqualsFunction<V>;
+    protected allowDuplicate: boolean;
 
     /**
      * Creates an empty multi dictionary.

--- a/src/lib/MultiRootTree.ts
+++ b/src/lib/MultiRootTree.ts
@@ -227,7 +227,7 @@ export default class MultiRootTree {
         }
     }
 
-    private moveId(moveId: string, beforeId: string, direction: Direction) {
+    protected moveId(moveId: string, beforeId: string, direction: Direction) {
 
         let sourceId = moveId;
         const sourceRootIndex = this.findRootId(sourceId);
@@ -397,21 +397,21 @@ export default class MultiRootTree {
         }
     }
 
-    private swapArrayElements(arr: Array<any>, indexA: number, indexB: number) {
+    protected swapArrayElements(arr: Array<any>, indexA: number, indexB: number) {
         var temp = arr[indexA];
         arr[indexA] = arr[indexB];
         arr[indexB] = temp;
         return arr;
     }
 
-    private rootDeleteId(id: string) {
+    protected rootDeleteId(id: string) {
         let index = this.findRootId(id);
         if (index > -1) {
             this.rootDelete(index);
         }
     }
 
-    private nodeAndSubNodesDelete(nodeKey: string) {
+    protected nodeAndSubNodesDelete(nodeKey: string) {
         let toDeleteLater: Array<string> = [];
         for (let i = 0; i < this.nodes[nodeKey].length; i++) {
             let id = this.nodes[nodeKey][i];
@@ -425,7 +425,7 @@ export default class MultiRootTree {
         }
     }
 
-    private nodeRefrencesDelete(id: string) {
+    protected nodeRefrencesDelete(id: string) {
         for (let nodeKey in this.nodes) {
             if (this.nodes.hasOwnProperty(nodeKey)) {
                 for (let i = 0; i < this.nodes[nodeKey].length; i++) {
@@ -438,45 +438,45 @@ export default class MultiRootTree {
         }
     }
 
-    private nodeDelete(nodeKey: string) {
+    protected nodeDelete(nodeKey: string) {
         delete this.nodes[nodeKey];
     }
 
 
-    private findRootId(id: string): number {
+    protected findRootId(id: string): number {
         return this.rootIds.indexOf(id);
     }
 
-    private findNodeId(nodeKey: string, id: string): number {
+    protected findNodeId(nodeKey: string, id: string): number {
         return this.nodes[nodeKey].indexOf(id);
     }
 
-    private findNode(nodeKey: string) {
+    protected findNode(nodeKey: string) {
         return this.nodes[nodeKey];
     }
 
 
-    private nodeInsertAtStart(nodeKey: string, id: string) {
+    protected nodeInsertAtStart(nodeKey: string, id: string) {
         this.nodes[nodeKey].unshift(id);
     }
 
-    private nodeInsertAtEnd(nodeKey: string, id: string) {
+    protected nodeInsertAtEnd(nodeKey: string, id: string) {
         this.nodes[nodeKey].push(id);
     }
 
-    private rootDelete(index: number) {
+    protected rootDelete(index: number) {
         this.rootIds.splice(index, 1);
     }
 
-    private nodeDeleteAtIndex(nodeKey: string, index: number) {
+    protected nodeDeleteAtIndex(nodeKey: string, index: number) {
         this.nodes[nodeKey].splice(index, 1);
     }
 
-    private rootInsertAtStart(id: string) {
+    protected rootInsertAtStart(id: string) {
         this.rootIds.unshift(id);
     }
 
-    private rootInsertAtEnd(id: string) {
+    protected rootInsertAtEnd(id: string) {
         this.rootIds.push(id);
     }
 }

--- a/src/lib/PriorityQueue.ts
+++ b/src/lib/PriorityQueue.ts
@@ -3,7 +3,7 @@ import Heap from './Heap';
 
 export default class PriorityQueue<T> {
 
-    private heap: Heap<T>;
+    protected heap: Heap<T>;
     /**
      * Creates an empty priority queue.
      * @class <p>In a priority queue each element is associated with a "priority",

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -6,9 +6,9 @@ export default class Queue<T> {
     /**
      * List containing the elements.
      * @type collections.LinkedList
-     * @private
+     * @protected
      */
-    private list: LinkedList<T>;
+    protected list: LinkedList<T>;
 
     /**
      * Creates an empty queue.

--- a/src/lib/Stack.ts
+++ b/src/lib/Stack.ts
@@ -5,9 +5,9 @@ export default class Stack<T> {
     /**
      * List containing the elements.
      * @type collections.LinkedList
-     * @private
+     * @protected
      */
-    private list: LinkedList<T>;
+    protected list: LinkedList<T>;
     /**
      * Creates an empty Stack.
      * @class A Stack is a Last-In-First-Out (LIFO) data structure, the last


### PR DESCRIPTION
This is a partial solution to issues #44 #91. It changes all private modifiers to protected, which I hope is not too controversial.

It doesn't provide any JSON-related functionality directly but would allow people who want to (de)serialize JSON to write their own extensions for doing so. In my case, I wanted to write something like that:

```
import { PriorityQueue } from 'typescript-collections'

export default class SerializablePriorityQueue<T> extends PriorityQueue<T>{
  public toJSON() {
    return this.heap.data
  }
}
```

But I had to work around it with a bit of a hack:

```
import { PriorityQueue } from 'typescript-collections'

export default class SerializablePriorityQueue<T> extends PriorityQueue<T>{
  public toJSON() {
    return (<any>this).heap.data
  }
}
```

Please let me know your thoughts about this proposed change :)