### PR TITLE
remove src ignoring

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ coverage/
 dist/test/
 examples/
 node_modules/
-src/
 temp/
 typings/
 


### PR DESCRIPTION
Hi,

The build add sourceMap files in dist folder, these sourcemap depend on src files.

Add many warnings in build tool chain when import this lib because of this.

Best regards