### PR TITLE
Added equality function to Bag, and added unit tests

### DIFF
--- a/src/lib/Bag.ts
+++ b/src/lib/Bag.ts
@@ -191,4 +191,24 @@ export default class Bag<T> {
         this.dictionary.clear();
     }
 
+    /**
+     * Returns true if both bags are subsets of each other.
+     * @return {boolean} true if this bag is equal to the other.
+     */
+    equals(bag: Bag<T>): boolean {
+        // all elements in this are elements in bag
+        for (let element of this.dictionary.values()) {
+            if (this.count(element) !== bag.count(element)) {
+                return false;
+            }
+        }
+
+        // all elements in bag are elements in this
+        for (let element of bag.dictionary.values()) {
+            if (this.count(element) !== bag.count(element)) {
+                return false;
+            }
+        }
+    return true;
+    }
 }// End of bag

--- a/src/test/bagTest.ts
+++ b/src/test/bagTest.ts
@@ -246,4 +246,27 @@ describe('Bag',
                 });
                 expect(t).equals(1);
             });
+
+        it('Non-empety bags with the same number of each element are equal',
+            function() {
+                let bag2 = new collections.Bag();
+                for (var i = 0; i < 5; i++) {
+                    bag.add(i);
+                    bag2.add(i);
+                }
+                expect(bag.equals(bag2)).equals(true);
+            });
+
+        it('Empty bags are equal',
+            function() {
+                let bag2 = new collections.Bag();
+                expect(bag.equals(bag2)).equals(true);
+            });
+
+        it('Bags with zero coppies of an element are equal to bags without the element',
+            function() {
+                let bag2 = new collections.Bag();
+                bag2.add(1, 0);
+                expect(bag.equals(bag2)).equals(true);
+            });
     });


### PR DESCRIPTION
I saw that Bag did not have an equality function yet. I'm submitting an implementation that is imperative and optimized because I assume that is desired, but below is more declarative solution as well. Both pass the three unit tests included in this pull request. 

```
equals(bag: Bag<T>): boolean {
        let allKeysSet = this.toSet();
        allKeysSet.union(bag.toSet());
        const allKeysArray = allKeysSet.toArray();
        return allKeysArray.every(element => this.count(element) === bag.count(element));
    }
```